### PR TITLE
propagate: rename schema:mainEntity to schema:object in ADA-core examples

### DIFF
--- a/examples/ADA-core-3qvv-wy22.json
+++ b/examples/ADA-core-3qvv-wy22.json
@@ -85,7 +85,7 @@
         ],
         "schema:alternateName": "UCB"
       },
-      "schema:mainEntity": [
+      "schema:object": [
         {
           "@type": [
             "schema:Thing",

--- a/examples/ADA-core-5856-1y66.json
+++ b/examples/ADA-core-5856-1y66.json
@@ -76,7 +76,7 @@
         ],
         "schema:alternateName": "UAZ"
       },
-      "schema:mainEntity": [
+      "schema:object": [
         {
           "@type": [
             "schema:Thing",

--- a/examples/ADA-core-6c5n-e486.json
+++ b/examples/ADA-core-6c5n-e486.json
@@ -76,7 +76,7 @@
         ],
         "schema:alternateName": "CIS"
       },
-      "schema:mainEntity": [
+      "schema:object": [
         {
           "@type": [
             "schema:Thing",

--- a/examples/ADA-core-89td-7k08.json
+++ b/examples/ADA-core-89td-7k08.json
@@ -85,7 +85,7 @@
         ],
         "schema:alternateName": "CSUSM"
       },
-      "schema:mainEntity": [
+      "schema:object": [
         {
           "@type": [
             "schema:Thing",

--- a/examples/ADA-core-917f-kr66.json
+++ b/examples/ADA-core-917f-kr66.json
@@ -94,7 +94,7 @@
         ],
         "schema:alternateName": "JSC-ARES"
       },
-      "schema:mainEntity": [
+      "schema:object": [
         {
           "@type": [
             "schema:Thing",

--- a/examples/ADA-core-j6f9-tp89.json
+++ b/examples/ADA-core-j6f9-tp89.json
@@ -85,7 +85,7 @@
         ],
         "schema:alternateName": "JSC-ARES"
       },
-      "schema:mainEntity": [
+      "schema:object": [
         {
           "@type": [
             "schema:Thing",

--- a/examples/ADA-core-q4b0-v203.json
+++ b/examples/ADA-core-q4b0-v203.json
@@ -112,7 +112,7 @@
         ],
         "schema:alternateName": "LLNL"
       },
-      "schema:mainEntity": [
+      "schema:object": [
         {
           "@type": [
             "schema:Thing",

--- a/examples/ADA-core-rd8a-6z91.json
+++ b/examples/ADA-core-rd8a-6z91.json
@@ -102,7 +102,7 @@
         ],
         "schema:alternateName": "NU"
       },
-      "schema:mainEntity": [
+      "schema:object": [
         {
           "@type": [
             "schema:Thing",

--- a/examples/ADA-core-xnxf-m505.json
+++ b/examples/ADA-core-xnxf-m505.json
@@ -85,7 +85,7 @@
         ],
         "schema:alternateName": "NMNH"
       },
-      "schema:mainEntity": [
+      "schema:object": [
         {
           "@type": [
             "schema:Thing",

--- a/examples/ADA-core-zh1b-jk54.json
+++ b/examples/ADA-core-zh1b-jk54.json
@@ -102,7 +102,7 @@
         ],
         "schema:alternateName": "CUWA"
       },
-      "schema:mainEntity": [
+      "schema:object": [
         {
           "@type": [
             "schema:Thing",


### PR DESCRIPTION
## Summary

- Part of a coordinated propagation across the CDIF/ADA ecosystem.
- Change: rename `schema:mainEntity` → `schema:object` in 10 ADA-core example files.
- Sibling PRs (this run):
  - mbb: https://github.com/Cross-Domain-Interoperability-Framework/metadataBuildingBlocks/pull/1
  - geochem: https://github.com/usgin/geochemBuildingBlocks/pull/1

## What changed

10 example files under `examples/ADA-core-*.json` had a `schema:mainEntity` key inside `prov:wasGeneratedBy.items` — the key is renamed to `schema:object`, value preserved verbatim. Confirmed by a repo-wide grep: zero occurrences of `schema:mainEntity` remain.

## Files

- examples/ADA-core-3qvv-wy22.json
- examples/ADA-core-5856-1y66.json
- examples/ADA-core-6c5n-e486.json
- examples/ADA-core-89td-7k08.json
- examples/ADA-core-917f-kr66.json
- examples/ADA-core-j6f9-tp89.json
- examples/ADA-core-q4b0-v203.json
- examples/ADA-core-rd8a-6z91.json
- examples/ADA-core-xnxf-m505.json
- examples/ADA-core-zh1b-jk54.json

## Validation

- Spot-checked 2 of the 10 (3qvv-wy22, zh1b-jk54) through `FrameAndValidate.py` — both pass.
- This PR is independent of the mbb/geochem cascade; can merge before or after them.

## Test plan

- [ ] Maintainer reviews the 10-file diff (1 line in / 1 line out per file).
- [ ] Confirm sibling PRs are linked correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)